### PR TITLE
add a new parameter about whether the app needs the microphone

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,11 @@ inputs:
       Would copy all contents to app/libs
       Top folder not included
     required: false
+  needs-microphone:
+    description: |
+      Whether it needs to use the microphone
+    required: false
+    default: false
   extra-assets:
     description: |
       List of folder & file paths to be added to app/src/embed/assets/
@@ -241,7 +246,7 @@ runs:
     - name: Build package (Debug)
       uses: burrunan/gradle-cache-action@v2
       with:
-        arguments: assembleEmbedRecordDebug
+        arguments: ${{ inputs.needs-microphone && 'assembleEmbedRecordDebug' || 'assembleEmbedNoRecordDebug' }}
         build-root-directory: ${{ inputs.love-actions-folder }}/love-android
         concurrent: true
         gradle-build-scan-report: false
@@ -249,7 +254,7 @@ runs:
     - name: Rename package (Debug)
       shell: bash
       run: |
-        mv ${{ inputs.love-actions-folder }}/love-android/app/build/outputs/apk/embedRecord/debug/app-embed-record-debug.apk ${{ inputs.output-folder }}/${{ inputs.product-name }}-debug.apk
+        mv ${{ inputs.love-actions-folder }}/love-android/app/build/outputs/apk/embed${{ inputs.needs-microphone && 'Record' || 'NoRecord' }}/debug/app-embed-${{ inputs.needs-microphone && 'record' || 'noRecord' }}-debug.apk ${{ inputs.output-folder }}/${{ inputs.product-name }}-debug.apk
     - name: Pre build (Release)
       if: "${{ inputs.keystore-alias != '' && inputs.keystore-base64 != '' && inputs.keystore-key-password != '' && inputs.keystore-store-password != '' }}"
       shell: bash
@@ -259,7 +264,7 @@ runs:
       uses: burrunan/gradle-cache-action@v2
       if: "${{ inputs.keystore-alias != '' && inputs.keystore-base64 != '' && inputs.keystore-key-password != '' && inputs.keystore-store-password != '' }}"
       with:
-        arguments: assembleEmbedRecordRelease
+        arguments: ${{ inputs.needs-microphone && 'assembleEmbedRecordRelease' || 'assembleEmbedNoRecordRelease' }}
         build-root-directory: ${{ inputs.love-actions-folder }}/love-android
         concurrent: true
         gradle-build-scan-report: false
@@ -268,7 +273,7 @@ runs:
     - name: Rename package (Release)
       if: "${{ inputs.keystore-alias != '' && inputs.keystore-base64 != '' && inputs.keystore-key-password != '' && inputs.keystore-store-password != '' }}"
       shell: bash
-      run: mv ${{ inputs.love-actions-folder }}/love-android/app/build/outputs/apk/embedRecord/release/app-embed-record-release.apk ${{ inputs.output-folder }}/${{ inputs.product-name }}-release.apk
+      run: mv ${{ inputs.love-actions-folder }}/love-android/app/build/outputs/apk/embed${{ inputs.needs-microphone && 'Record' || 'NoRecord' }}/release/app-embed-${{ inputs.needs-microphone && 'record' || 'noRecord' }}-release.apk ${{ inputs.output-folder }}/${{ inputs.product-name }}-release.apk
     - name: Gather packages in output folder
       id: gather-packages
       shell: bash


### PR DESCRIPTION
adds a new parameter `needs-microphone` to indicate whether the app needs the microphone permission.

Note that this is a breaking change: the app used to always ask for the microphone permission. The new parameter is defaulted to false, so, even if the user's GitHub actions does not change, the built apk will silently not ask for microphone permission.

Related to https://github.com/26F-Studio/Techmino/issues/1203 .